### PR TITLE
Simplify App.svelte theme, binary conversion, and toString

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ULID Timestamp Converter — a single-page web app that converts between ULID and timestamps. Hosted on GitHub Pages at https://ugai.github.io/ulid-timestamp-converter/.
+
+## Commands
+
+- `npm run dev` — Start Vite dev server
+- `npm run build` — Production build (output: `dist/`)
+- `npm run check` — Type-check Svelte and Node TypeScript configs
+- `npm run preview` — Preview production build locally
+- `npm run publish-gh-pages` — Build and deploy to GitHub Pages
+
+No test framework is configured.
+
+## Architecture
+
+- **Svelte 5 + TypeScript + Vite** single-page app
+- All application logic lives in `src/App.svelte` (single component, no routing)
+- Uses `ulidx` library for ULID encode/decode operations
+- Svelte 5 runes (`$state`, `$effect`) for reactivity
+- Two input modes: ULID string → timestamp, or datetime → ULID timestamp part
+- Output shows decoded timestamp in multiple formats plus Crockford Base32/decimal/binary/hex breakdown
+- Global styles in `public/global.css`; component styles scoped in `App.svelte`
+- Dark/light theme toggle via `body[dark-theme]` attribute

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,28 +6,10 @@
   const repositoryUrl = "https://github.com/ugai/ulid-timestamp-converter/";
 
   // dynamic theming {{{
-  const darkTheme = "dark";
-  const lightTheme = "light";
-  let currentTheme: string = $state(lightTheme);
-
-  const darkThemeAttr = "dark-theme";
-  const preferredDark = "(prefers-color-scheme: dark)";
-  const preferredTheme = () => {
-    return window.matchMedia(preferredDark).matches ? darkTheme : lightTheme;
-  };
-  const updateTheme = (theme: string) => {
-    if (theme == darkTheme) {
-      document.body.setAttribute(darkThemeAttr, theme);
-    } else {
-      document.body.removeAttribute(darkThemeAttr);
-    }
-  };
-  const toggleTheme = () => {
-    currentTheme = currentTheme == darkTheme ? lightTheme : darkTheme;
-  };
+  let dark = $state(false);
 
   $effect(() => {
-    updateTheme(currentTheme);
+    document.body.toggleAttribute("dark-theme", dark);
   });
   // }}} dynamic theming
 
@@ -61,7 +43,7 @@
 
   class UlidInputField extends InputFieldBase {
     set_random_value() {
-      this.value = ulid().toString();
+      this.value = ulid();
     }
   }
 
@@ -129,11 +111,7 @@
         const dec = CROCKFORD_BASE32_CHARS.indexOf(base32Char);
         decValues.push(dec);
 
-        let bin = "";
-        for (let pos = 4; pos >= 0; pos--) {
-          bin += (dec & (1 << pos)) > 0 ? "1" : "0";
-        }
-        binValues.push(bin);
+        binValues.push(dec.toString(2).padStart(5, "0"));
       }
       binValues[0] = binValues[0].slice(2);
       const binAll = binValues.join("");
@@ -208,7 +186,7 @@
     try {
       const epochMs = new Date(v).getTime();
       const tsPart = encodeTime(epochMs, ULID_TIMESTAMP_LENGTH);
-      const rsPart = ulid().toString().slice(ULID_TIMESTAMP_LENGTH);
+      const rsPart = ulid().slice(ULID_TIMESTAMP_LENGTH);
       outputs.update(tsPart, rsPart, epochMs);
 
       inputDateTime.errorMessage = "";
@@ -221,14 +199,14 @@
   };
 
   onMount(() => {
-    currentTheme = preferredTheme();
+    dark = window.matchMedia("(prefers-color-scheme: dark)").matches;
     inputUlid.set_random_value();
   });
 </script>
 
 <main>
   <div class="theme-toggle">
-    <button class="button" onclick={toggleTheme} aria-label="Toggle theme">
+    <button class="button" onclick={() => dark = !dark} aria-label="Toggle theme">
       Light/Dark
     </button>
     <a


### PR DESCRIPTION
## Summary
- Simplify theme management: replace 4 constants + 2 functions with a single `$state(false)` boolean and `toggleAttribute`
- Replace manual bit-loop for binary conversion with `dec.toString(2).padStart(5, "0")`
- Remove redundant `.toString()` on `ulid()` calls (already returns string)
- Add `CLAUDE.md` for Claude Code guidance

## Test plan
- [x] `npm run check` passes (verified locally)
- [x] Light/Dark theme toggle works correctly
- [x] ULID → timestamp conversion produces correct output
- [x] Date → ULID timestamp conversion produces correct output
- [x] Binary values in encoding table display correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)